### PR TITLE
Show block even when no data

### DIFF
--- a/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
+++ b/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
@@ -1,15 +1,18 @@
-{if $existingRelationships}
-  <div id="crm-relblock-content" class="crm-inline-edit"  {literal}data-edit-params='{"cid": {/literal}{$contactId}{literal}, "class_name": "CRM_Relationshipblock_Form_Inline_RelationshipBlock"}'{/literal}>
-    <div class="crm-clear crm-inline-block-content" title="Edit info">
-      <div class="crm-edit-help"><span class="crm-i fa-pencil"></span>{ts}Edit info{/ts}</div>
-      <div class="crm-clear crm-inline-block-content">
-        <div class="crm-summary-row" >
+<div id="crm-relblock-content" class="crm-inline-edit"  {literal}data-edit-params='{"cid": {/literal}{$contactId}{literal}, "class_name": "CRM_Relationshipblock_Form_Inline_RelationshipBlock"}'{/literal}>
+  <div class="crm-clear crm-inline-block-content" title="{ts escape='html'}Edit info{/ts}">
+    <div class="crm-edit-help"><span class="crm-i fa-pencil"></span>{ts}Edit info{/ts}</div>
+    <div class="crm-clear crm-inline-block-content">
+      <div class="crm-summary-row" >
+        {if $existingRelationships}
           {foreach from=$existingRelationships item=existingRelationship}
             <div class="crm-label">{$existingRelationship.relationship_type}</div>
             <div class="crm-content">{$existingRelationship.relation_display_name}</div>
           {/foreach}
-        </div>
+        {else}
+          <div class="crm-label">{ts}Key Relationships{/ts}</div>
+          <div class="crm-content"></div>
+        {/if}
       </div>
     </div>
   </div>
-{/if}
+</div>


### PR DESCRIPTION
I notice that this extension has a different behavior to most other inline-edit blocks on the contact summary screen. Other blocks are shown even if they contain no data, but this one is hidden. This change fixes that so that key relationships can be added if they don't exist (similar to address, phone, and custom data blocks).