### PR TITLE
Show deceased status

### DIFF
--- a/CRM/Relationshipblock/Utils/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Utils/RelationshipBlock.php
@@ -21,7 +21,9 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
       'is_active' => 1,
       'contact_id_a' => $contactID,
       'contact_id_b' => $contactID,
-      'return' => ['id', 'relationship_type_id', 'contact_id_a', 'contact_id_b', 'contact_id_a.display_name', 'contact_id_b.display_name'],
+      'return' => ['id', 'relationship_type_id', 'contact_id_a', 'contact_id_b',
+        'contact_id_a.display_name', 'contact_id_b.display_name', 'contact_id_a.is_deceased',
+        'contact_id_b.is_deceased'],
       'options' => ['limit' => 0, 'or' => [['contact_id_a', 'contact_id_b']]],
     ]);
     $ret = [];
@@ -40,6 +42,7 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
         'contact_id' => $rel["contact_id_$b"],
         'relationship_id' => $rel['id'],
         'display_name' => $rel["contact_id_$b.display_name"],
+        'is_deceased' => $rel["contact_id_$b.is_deceased"],
       ];
     }
     return $ret;

--- a/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
+++ b/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
@@ -10,7 +10,7 @@
             <span>
               {foreach from=$existingRelationship.contacts item=contact name=rel}
                 <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$contact.contact_id`"}" title="{ts escape='html'}view contact{/ts}">
-                  {$contact.display_name|escape}</a>{if not $smarty.foreach.rel.last and $i neq 6},
+                  {$contact.display_name|escape}</a>{if $contact.is_deceased} <span class="crm-contact-deceased">(deceased)</span>{/if}{if not $smarty.foreach.rel.last and $i neq 6},
                 {elseif $i eq 6}</span><span class="relblock-show-more">... <a href="#">{ts}(more){/ts}</a></span><span style="display:none">{/if}
                 {assign var='i' value=$i+1}
               {/foreach}


### PR DESCRIPTION
Discussions with a client led me to believe that showing "deceased" status on the relationship block was important to most folks who would want to view family relationships on the Summary tab.  This PR adds the deceased data to the relationship block.