### PR TITLE
CIVICRM-1486: Ensure $permission is set correctly for Inline Page.

### DIFF
--- a/CRM/Relationshipblock/Page/Inline/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Page/Inline/RelationshipBlock.php
@@ -10,6 +10,12 @@ class CRM_Relationshipblock_Page_Inline_RelationshipBlock extends CRM_Core_Page 
       return;
     }
     self::addKeyRelationshipsBlock($this, $contactId);
+
+    // check logged in user permission
+    if (!isset($page->_permission)) {
+      CRM_Contact_Page_View::checkUserPermission($this, $contactId);
+    }
+
     parent::run();
   }
 


### PR DESCRIPTION
For "inline" Page views called via AJAX, `CRM_Contact_Page_View::checkUserPermission` appears to need to be called by the Page's own `run()` function.

In this case, the effect of not doing this is that `$permission` is not set, so the TPL doesn't include the data-edit-params required to reload the block a second time.

This adds the permission check in.