### PR TITLE
Do not load deleted contacts on summary screen

### DIFF
--- a/CRM/Relationshipblock/Utils/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Utils/RelationshipBlock.php
@@ -21,6 +21,8 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
       'is_active' => 1,
       'contact_id_a' => $contactID,
       'contact_id_b' => $contactID,
+      'contact_id_a.is_deleted' => ['!=' => 1],
+      'contact_id_b.is_deleted' => ['!=' => 1],
       'return' => [
         'id',
         'relationship_type_id',


### PR DESCRIPTION
**Before**: Trashed contacts are loaded on the summary screen.

![image](https://user-images.githubusercontent.com/5929648/92912899-e16b9180-f447-11ea-83a8-55316405bf3e.png)

**After**: Trashed contacts are excluded.

![image](https://user-images.githubusercontent.com/5929648/92912964-f0524400-f447-11ea-85c6-32fec68b1a17.png)

