### PR TITLE
Show default position in contactlayout extension

### DIFF
--- a/relationshipblock.php
+++ b/relationshipblock.php
@@ -196,5 +196,6 @@ function relationshipblock_civicrm_contactSummaryBlocks(&$blocks) {
     'tpl_file' => 'CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl',
     'sample' => [E::ts('Relationship %1', [1 => 1]), E::ts('Relationship %1', [1 => 2]), E::ts('Relationship %1', [1 => 3])],
     'edit' => 'civicrm/admin/reltype?reset=1',
+    'system_default' => [0, 1],
   ];
 }


### PR DESCRIPTION
This shows the relationship block in the "System Default" layout in Contact Summary Editor 2.0+.

It's backward-compatible with earlier versions of the extension (which will ignore the new property).

Also see https://github.com/civicrm/civicrm-core/pull/20228