### PR TITLE
Improve displaying

### DIFF
--- a/CRM/Relationshipblock/Page/Inline/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Page/Inline/RelationshipBlock.php
@@ -27,6 +27,8 @@ class CRM_Relationshipblock_Page_Inline_RelationshipBlock extends CRM_Core_Page 
     $existingRelationships = CRM_Relationshipblock_Utils_RelationshipBlock::getExistingRelationships($contactId);
     $page->assign('contactId', $contactId);
     $page->assign('existingRelationships', $existingRelationships);
+    $page->assign('settingContactFields', CRM_Relationshipblock_Settings::getContactFields());
+    $page->assign('settingRelationshipFields', CRM_Relationshipblock_Settings::getRelationshipFields());
     if (!$existingRelationships) {
       $relTypes = CRM_Relationshipblock_Utils_RelationshipBlock::getDisplayedRelationshipTypes($contactId);
       $page->assign('keyRelationshipLabel', count($relTypes) > 1 ? E::ts('Key Relationships') : CRM_Utils_Array::first($relTypes)['label']);

--- a/CRM/Relationshipblock/Page/Inline/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Page/Inline/RelationshipBlock.php
@@ -22,16 +22,36 @@ class CRM_Relationshipblock_Page_Inline_RelationshipBlock extends CRM_Core_Page 
   /**
    * @param CRM_Core_Page $page
    * @param int $contactId
+   * @throws CiviCRM_API3_Exception
    */
   public static function addKeyRelationshipsBlock(&$page, $contactId) {
     $existingRelationships = CRM_Relationshipblock_Utils_RelationshipBlock::getExistingRelationships($contactId);
     $page->assign('contactId', $contactId);
     $page->assign('existingRelationships', $existingRelationships);
-    $page->assign('settingFields', array_merge(CRM_Relationshipblock_Settings::getContactFields(), CRM_Relationshipblock_Settings::getRelationshipFields()));
+    $settingFields = array_merge(CRM_Relationshipblock_Settings::getContactFields(), CRM_Relationshipblock_Settings::getRelationshipFields());
+    $page->assign('settingFields', $settingFields);
+    $page->assign('settingLabels', self::getSettingLabels($settingFields));
     if (!$existingRelationships) {
       $relTypes = CRM_Relationshipblock_Utils_RelationshipBlock::getDisplayedRelationshipTypes($contactId);
       $page->assign('keyRelationshipLabel', count($relTypes) > 1 ? E::ts('Key Relationships') : CRM_Utils_Array::first($relTypes)['label']);
     }
+  }
+
+  /**
+   * @param array $settingFields
+   * @return array
+   * @throws CiviCRM_API3_Exception
+   */
+  private static function getSettingLabels(array $settingFields): array {
+    $labels = [];
+    if (CRM_Relationshipblock_Settings::getDisplayLabels()) {
+      $list = array_merge(CRM_Relationshipblock_Settings::contactFieldsList(), CRM_Relationshipblock_Settings::relationshipFieldsList());
+      foreach ($settingFields as $field) {
+        $labels[$field] = $list[$field];
+      }
+    }
+
+    return $labels;
   }
 
 }

--- a/CRM/Relationshipblock/Page/Inline/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Page/Inline/RelationshipBlock.php
@@ -27,8 +27,7 @@ class CRM_Relationshipblock_Page_Inline_RelationshipBlock extends CRM_Core_Page 
     $existingRelationships = CRM_Relationshipblock_Utils_RelationshipBlock::getExistingRelationships($contactId);
     $page->assign('contactId', $contactId);
     $page->assign('existingRelationships', $existingRelationships);
-    $page->assign('settingContactFields', CRM_Relationshipblock_Settings::getContactFields());
-    $page->assign('settingRelationshipFields', CRM_Relationshipblock_Settings::getRelationshipFields());
+    $page->assign('settingFields', array_merge(CRM_Relationshipblock_Settings::getContactFields(), CRM_Relationshipblock_Settings::getRelationshipFields()));
     if (!$existingRelationships) {
       $relTypes = CRM_Relationshipblock_Utils_RelationshipBlock::getDisplayedRelationshipTypes($contactId);
       $page->assign('keyRelationshipLabel', count($relTypes) > 1 ? E::ts('Key Relationships') : CRM_Utils_Array::first($relTypes)['label']);

--- a/CRM/Relationshipblock/Settings.php
+++ b/CRM/Relationshipblock/Settings.php
@@ -19,6 +19,22 @@ class CRM_Relationshipblock_Settings {
   }
 
   /**
+   * @return array
+   * @throws CiviCRM_API3_Exception
+   */
+  public static function relationshipFields(): array {
+    $result = civicrm_api3('Relationship', 'getfields', [
+      'api_action' => "get",
+    ]);
+    $fields = [];
+    foreach ($result['values'] as $field) {
+      $fields[$field['name']] = $field['title'];
+    }
+
+    return $fields;
+  }
+
+  /**
    * Get setting saved as serialized by separator.
    * @param string $settingName
    * @return array

--- a/CRM/Relationshipblock/Settings.php
+++ b/CRM/Relationshipblock/Settings.php
@@ -18,4 +18,18 @@ class CRM_Relationshipblock_Settings {
     return $fields;
   }
 
+  /**
+   * Get setting saved as serialized by separator.
+   * @param string $settingName
+   * @return array
+   */
+  public static function getArray(string $settingName): array {
+    $value = Civi::settings()->get($settingName);
+    if ($value) {
+      return explode(CRM_Core_DAO::VALUE_SEPARATOR, trim($value, CRM_Core_DAO::VALUE_SEPARATOR));
+    }
+
+    return [];
+  }
+
 }

--- a/CRM/Relationshipblock/Settings.php
+++ b/CRM/Relationshipblock/Settings.php
@@ -6,7 +6,7 @@ class CRM_Relationshipblock_Settings {
    * @return array
    * @throws CiviCRM_API3_Exception
    */
-  public static function contactFields(): array {
+  public static function contactFieldsList(): array {
     $result = civicrm_api3('Contact', 'getfields', [
       'api_action' => "get",
     ]);
@@ -22,7 +22,7 @@ class CRM_Relationshipblock_Settings {
    * @return array
    * @throws CiviCRM_API3_Exception
    */
-  public static function relationshipFields(): array {
+  public static function relationshipFieldsList(): array {
     $result = civicrm_api3('Relationship', 'getfields', [
       'api_action' => "get",
     ]);

--- a/CRM/Relationshipblock/Settings.php
+++ b/CRM/Relationshipblock/Settings.php
@@ -35,11 +35,25 @@ class CRM_Relationshipblock_Settings {
   }
 
   /**
+   * @return array
+   */
+  public static function getContactFields(): array {
+    return CRM_Relationshipblock_Settings::getArray('relationshipblock_contact_fields');
+  }
+
+  /**
+   * @return array
+   */
+  public static function getRelationshipFields(): array {
+    return CRM_Relationshipblock_Settings::getArray('relationshipblock_relationship_fields');
+  }
+
+  /**
    * Get setting saved as serialized by separator.
    * @param string $settingName
    * @return array
    */
-  public static function getArray(string $settingName): array {
+  private static function getArray(string $settingName): array {
     $value = Civi::settings()->get($settingName);
     if ($value) {
       return explode(CRM_Core_DAO::VALUE_SEPARATOR, trim($value, CRM_Core_DAO::VALUE_SEPARATOR));

--- a/CRM/Relationshipblock/Settings.php
+++ b/CRM/Relationshipblock/Settings.php
@@ -35,6 +35,13 @@ class CRM_Relationshipblock_Settings {
   }
 
   /**
+   * @return int
+   */
+  public static function getDisplayLabels(): int {
+    return (int) Civi::settings()->get('relationshipblock_display_labels');
+  }
+
+  /**
    * @return array
    */
   public static function getContactFields(): array {

--- a/CRM/Relationshipblock/Settings.php
+++ b/CRM/Relationshipblock/Settings.php
@@ -1,0 +1,21 @@
+<?php
+
+class CRM_Relationshipblock_Settings {
+
+  /**
+   * @return array
+   * @throws CiviCRM_API3_Exception
+   */
+  public static function contactFields(): array {
+    $result = civicrm_api3('Contact', 'getfields', [
+      'api_action' => "get",
+    ]);
+    $fields = [];
+    foreach ($result['values'] as $field) {
+      $fields[$field['name']] = $field['title'];
+    }
+
+    return $fields;
+  }
+
+}

--- a/CRM/Relationshipblock/Utils/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Utils/RelationshipBlock.php
@@ -88,6 +88,11 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
           'display_name' => $rel["contact_id_$b.display_name"],
           'is_deceased' => $rel["contact_id_$b.is_deceased"],
         ];
+        if (array_key_exists('api.Contact.getsingle', $rel)) {
+          foreach (CRM_Relationshipblock_Settings::getContactFields() as $field) {
+            $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$field];
+          }
+        }
       }
     }
     return $ret;
@@ -101,7 +106,7 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
   private static function extendParams(array $params): array {
     $additionalContactFields = CRM_Relationshipblock_Settings::getContactFields();
     if ($additionalContactFields) {
-      $params['api.Contact.get'] = [
+      $params['api.Contact.getsingle'] = [
         'id' => '$value.contact_id_a',
         'return' => $additionalContactFields,
       ];

--- a/CRM/Relationshipblock/Utils/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Utils/RelationshipBlock.php
@@ -42,6 +42,7 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
         'or' => [['contact_id_a', 'contact_id_b']],
       ],
     ];
+    $params = self::extendParams($params);
     $existingRelationships = civicrm_api3('Relationship', 'get', $params);
     $exclude_expired_field_id = civicrm_api3('CustomField', 'getvalue', [
       'name' => 'relationship_block_exclude_expired',
@@ -90,6 +91,27 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
       }
     }
     return $ret;
+  }
+
+  /**
+   * Get additional fields based on extension configuration
+   * @param array $params
+   * @return array
+   */
+  private static function extendParams(array $params): array {
+    $additionalContactFields = CRM_Relationshipblock_Settings::getContactFields();
+    if ($additionalContactFields) {
+      $params['api.Contact.get'] = [
+        'id' => '$value.contact_id_a',
+        'return' => $additionalContactFields,
+      ];
+    }
+    $additionalRelationshipFields = CRM_Relationshipblock_Settings::getContactFields();
+    foreach ($additionalRelationshipFields as $field) {
+      $params['return'][] = $field;
+    }
+
+    return $params;
   }
 
   /**

--- a/CRM/Relationshipblock/Utils/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Utils/RelationshipBlock.php
@@ -88,36 +88,7 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
           'display_name' => $rel["contact_id_$b.display_name"],
           'is_deceased' => $rel["contact_id_$b.is_deceased"],
         ];
-        if (array_key_exists('api.Contact.getsingle', $rel)) {
-          foreach (CRM_Relationshipblock_Settings::getContactFields() as $field) {
-            if (strpos($field, 'custom') === 0) {
-              $options = CRM_Contact_BAO_Contact::buildOptions($field);
-              if ($options) {
-                $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$options[$field]];
-              }
-              else {
-                $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$field];
-              }
-            }
-            else {
-              $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$field];
-            }
-          }
-        }
-        foreach (CRM_Relationshipblock_Settings::getRelationshipFields() as $field) {
-          if (strpos($field, 'custom') === 0) {
-            $options = CRM_Contact_BAO_Contact::buildOptions($field);
-            if ($options) {
-              $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel[$options[$field]];
-            }
-            else {
-              $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel[$field];
-            }
-          }
-          else {
-            $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel[$field];
-          }
-        }
+        self::extendContacts($ret, $rel, $key, $b);
       }
     }
     return $ret;
@@ -142,6 +113,47 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
     }
 
     return $params;
+  }
+
+  /**
+   * Extend contacts about additional fields from settings.
+   * Improve custom fields with options.
+   * @param $ret
+   * @param $rel
+   * @param $key
+   * @param $b
+   */
+  private static function extendContacts(&$ret, $rel, $key, $b): void {
+    if (array_key_exists('api.Contact.getsingle', $rel)) {
+      foreach (CRM_Relationshipblock_Settings::getContactFields() as $field) {
+        if (strpos($field, 'custom') === 0) {
+          $options = CRM_Contact_BAO_Contact::buildOptions($field);
+          if ($options) {
+            $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $options[$rel['api.Contact.getsingle'][$field]];
+          }
+          else {
+            $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$field];
+          }
+        }
+        else {
+          $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$field];
+        }
+      }
+    }
+    foreach (CRM_Relationshipblock_Settings::getRelationshipFields() as $field) {
+      if (strpos($field, 'custom') === 0) {
+        $options = CRM_Contact_BAO_Contact::buildOptions($field);
+        if ($options) {
+          $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $options[$rel[$field]];
+        }
+        else {
+          $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel[$field];
+        }
+      }
+      else {
+        $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel[$field];
+      }
+    }
   }
 
   /**

--- a/CRM/Relationshipblock/Utils/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Utils/RelationshipBlock.php
@@ -90,11 +90,33 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
         ];
         if (array_key_exists('api.Contact.getsingle', $rel)) {
           foreach (CRM_Relationshipblock_Settings::getContactFields() as $field) {
-            $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$field];
+            if (strpos($field, 'custom') === 0) {
+              $options = CRM_Contact_BAO_Contact::buildOptions($field);
+              if ($options) {
+                $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$options[$field]];
+              }
+              else {
+                $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$field];
+              }
+            }
+            else {
+              $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$field];
+            }
           }
         }
         foreach (CRM_Relationshipblock_Settings::getRelationshipFields() as $field) {
-          $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel[$field];
+          if (strpos($field, 'custom') === 0) {
+            $options = CRM_Contact_BAO_Contact::buildOptions($field);
+            if ($options) {
+              $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel[$options[$field]];
+            }
+            else {
+              $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel[$field];
+            }
+          }
+          else {
+            $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel[$field];
+          }
         }
       }
     }

--- a/CRM/Relationshipblock/Utils/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Utils/RelationshipBlock.php
@@ -16,7 +16,7 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
       return [];
     }
     $displayedRelationships = CRM_Utils_Array::rekey($displayedRelationships, 'id');
-    $existingRelationships = civicrm_api3('Relationship', 'get', [
+    $params = [
       'relationship_type_id' => ['IN' => array_keys($displayedRelationships)],
       'is_active' => 1,
       'contact_id_a' => $contactID,
@@ -41,7 +41,8 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
         'sort' => 'relationship_type_id.label_a_b ASC',
         'or' => [['contact_id_a', 'contact_id_b']],
       ],
-    ]);
+    ];
+    $existingRelationships = civicrm_api3('Relationship', 'get', $params);
     $exclude_expired_field_id = civicrm_api3('CustomField', 'getvalue', [
       'name' => 'relationship_block_exclude_expired',
       'return' => 'id',

--- a/CRM/Relationshipblock/Utils/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Utils/RelationshipBlock.php
@@ -93,6 +93,9 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
             $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel['api.Contact.getsingle'][$field];
           }
         }
+        foreach (CRM_Relationshipblock_Settings::getRelationshipFields() as $field) {
+          $ret[$key]['contacts'][$rel["contact_id_$b"]][$field] = $rel[$field];
+        }
       }
     }
     return $ret;

--- a/CRM/Relationshipblock/Utils/RelationshipBlock.php
+++ b/CRM/Relationshipblock/Utils/RelationshipBlock.php
@@ -106,7 +106,7 @@ class CRM_Relationshipblock_Utils_RelationshipBlock {
         'return' => $additionalContactFields,
       ];
     }
-    $additionalRelationshipFields = CRM_Relationshipblock_Settings::getContactFields();
+    $additionalRelationshipFields = CRM_Relationshipblock_Settings::getRelationshipFields();
     foreach ($additionalRelationshipFields as $field) {
       $params['return'][] = $field;
     }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ org.wikimedia.relationshipblock
 
 ![Screenshot](/images/relationship_block.gif)
 
-This extension adds a block to the contact summary that allows editing of 
+This extension adds a block to the contact summary that allows editing of
 any configured relationship type with a UI similar to the employer field.
 
 When the field is edited the relationship is updated.
@@ -26,6 +26,12 @@ Once installed the extension will do nothing until you select one or more relati
 - Navigate to **Administer -> Customize Data & Screens -> Relationship Types** and click edit on a desired relationship type.
 - Select "Display block on contact summary." for that relationship type.
 - Now you can visit a contact to view and edit their key relationships.
+
+You can also display additional fields about contacts and relationships:
+
+- Navigate to **Administer -> Administration Console -> Relationship Block settings**.
+- Choose fields on *Contact fields* and/or *Relationship fields* settings and save.
+- Visit a contact to see more fields near to display name.
 
 ### Extras
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Once installed the extension will do nothing until you select one or more relati
 You can also display additional fields about contacts and relationships:
 
 - Navigate to **Administer -> Administration Console -> Relationship Block settings**.
-- Choose fields on *Contact fields* and/or *Relationship fields* settings and save.
-- Visit a contact to see more fields near to display name.
+- Choose fields on *Contact fields* and/or *Relationship fields*.
+- Decide whether before value will be displayed a label of field: *Yes* or *No*.
+- Save settings and visit a contact to see more fields near to display name.
 
 ### Extras
 

--- a/settings/relationshipblock.setting.php
+++ b/settings/relationshipblock.setting.php
@@ -43,4 +43,17 @@ return [
     'is_contact' => 0,
     'settings_pages' => ['relationshipblock' => ['weight' => 20]],
   ],
+  'relationshipblock_display_labels' => [
+    'name' => 'relationshipblock_display_labels',
+    'title' => E::ts('Display labels'),
+    'description' => E::ts('Decide whether before value will be displayed a label of field'),
+    'type' => 'Integer',
+    'html_type' => 'radio',
+    'options' => [0 => E::ts('No, only value of fields'), 1 => E::ts('Yes, each field has own label')],
+    'default' => 0,
+    'add' => '5.43',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'settings_pages' => ['relationshipblock' => ['weight' => 30]],
+  ],
 ];

--- a/settings/relationshipblock.setting.php
+++ b/settings/relationshipblock.setting.php
@@ -1,0 +1,26 @@
+<?php
+
+use CRM_Relationshipblock_ExtensionUtil as E;
+
+return [
+  'relationshipblock_contact_fields' => [
+    'name' => 'relationshipblock_contact_fields',
+    'title' => E::ts('Contact fields'),
+    'description' => E::ts('Additional contact fields displayed on block'),
+    'type' => 'String',
+    'html_type' => 'select',
+    'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED, // SERIALIZE_JSON still doesn't work
+    'html_attributes' => [
+      'multiple' => 1,
+      'class' => 'huge crm-select2',
+    ],
+    'pseudoconstant' => [
+      'callback' => 'CRM_Relationshipblock_Settings::contactFields',
+    ],
+    'default' => '',
+    'add' => '5.43',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'settings_pages' => ['relationshipblock' => ['weight' => 10]],
+  ],
+];

--- a/settings/relationshipblock.setting.php
+++ b/settings/relationshipblock.setting.php
@@ -23,4 +23,24 @@ return [
     'is_contact' => 0,
     'settings_pages' => ['relationshipblock' => ['weight' => 10]],
   ],
+  'relationshipblock_relationship_fields' => [
+    'name' => 'relationshipblock_relationship_fields',
+    'title' => E::ts('Relationship fields'),
+    'description' => E::ts('Additional relationship fields displayed on block'),
+    'type' => 'String',
+    'html_type' => 'select',
+    'serialize' => CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED, // SERIALIZE_JSON still doesn't work
+    'html_attributes' => [
+      'multiple' => 1,
+      'class' => 'huge crm-select2',
+    ],
+    'pseudoconstant' => [
+      'callback' => 'CRM_Relationshipblock_Settings::relationshipFields',
+    ],
+    'default' => '',
+    'add' => '5.43',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'settings_pages' => ['relationshipblock' => ['weight' => 20]],
+  ],
 ];

--- a/settings/relationshipblock.setting.php
+++ b/settings/relationshipblock.setting.php
@@ -15,7 +15,7 @@ return [
       'class' => 'huge crm-select2',
     ],
     'pseudoconstant' => [
-      'callback' => 'CRM_Relationshipblock_Settings::contactFields',
+      'callback' => 'CRM_Relationshipblock_Settings::contactFieldsList',
     ],
     'default' => '',
     'add' => '5.43',
@@ -35,7 +35,7 @@ return [
       'class' => 'huge crm-select2',
     ],
     'pseudoconstant' => [
-      'callback' => 'CRM_Relationshipblock_Settings::relationshipFields',
+      'callback' => 'CRM_Relationshipblock_Settings::relationshipFieldsList',
     ],
     'default' => '',
     'add' => '5.43',

--- a/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
+++ b/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
@@ -14,6 +14,9 @@
                 <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$contact.contact_id`"}" title="{ts escape='html'}view contact{/ts}">
                   {$contact.display_name|escape}</a>{if $contact.is_deceased} <span class="crm-contact-deceased">(deceased)</span>{/if}{if not $smarty.foreach.rel.last and $i neq 6},
                 {elseif $i eq 6}</span><span class="relblock-show-more">... <a href="#">{ts}(more){/ts}</a></span><span style="display:none">{/if}
+                  {foreach from=$settingContactFields item=field}
+                      <span>{$contact[$field]}, </span>
+                  {/foreach}
                 {assign var='i' value=$i+1}
               {/foreach}
             </span>

--- a/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
+++ b/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
@@ -16,7 +16,12 @@
                 {elseif $i eq 6}</span><span class="relblock-show-more">... <a href="#">{ts}(more){/ts}</a></span><span style="display:none">{/if}
                   {foreach from=$settingFields item=field name=settingFields}
                     {if !empty($contact[$field])}
-                      {$contact[$field]}{if !$smarty.foreach.settingFields.last}, {/if}
+                      {assign var='validEmail' value=$contact[$field]|filter_var:$smarty.const.FILTER_VALIDATE_EMAIL}
+                      {if $contact[$field] eq $validEmail}
+                         <a href="mailto:{$validEmail}" title="{ts}Click to send email{/ts}">{$validEmail}</a>{if !$smarty.foreach.settingFields.last}, {/if}
+                      {else}
+                        {$contact[$field]}{if !$smarty.foreach.settingFields.last}, {/if}
+                      {/if}
                     {/if}
                     {if $smarty.foreach.settingFields.last}<br>{/if}
                   {/foreach}

--- a/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
+++ b/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
@@ -17,6 +17,8 @@
                   {foreach from=$settingFields item=field name=settingFields}
                     {if !empty($contact[$field])}
                       {assign var='validEmail' value=$contact[$field]|filter_var:$smarty.const.FILTER_VALIDATE_EMAIL}
+                      {assign var='settingLabel' value=$settingLabels[$field]}
+                      {if $settingLabel}<em>{$settingLabel}:</em>{/if}
                       {if $contact[$field] eq $validEmail}
                          <a href="mailto:{$validEmail}" title="{ts}Click to send email{/ts}">{$validEmail}</a>{if !$smarty.foreach.settingFields.last}, {/if}
                       {else}

--- a/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
+++ b/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
@@ -18,6 +18,7 @@
                     {if !empty($contact[$field])}
                       {$contact[$field]}{if !$smarty.foreach.settingFields.last}, {/if}
                     {/if}
+                    {if $smarty.foreach.settingFields.last}<br>{/if}
                   {/foreach}
                 {assign var='i' value=$i+1}
               {/foreach}

--- a/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
+++ b/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
@@ -16,7 +16,7 @@
                 {elseif $i eq 6}</span><span class="relblock-show-more">... <a href="#">{ts}(more){/ts}</a></span><span style="display:none">{/if}
                   {foreach from=$settingFields item=field name=settingFields}
                     {if !empty($contact[$field])}
-                      <span>{$contact[$field]}{if $smarty.foreach.settingFields.last}.{else}, {/if}</span>
+                      {$contact[$field]}{if !$smarty.foreach.settingFields.last}, {/if}
                     {/if}
                   {/foreach}
                 {assign var='i' value=$i+1}

--- a/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
+++ b/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
@@ -14,8 +14,10 @@
                 <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$contact.contact_id`"}" title="{ts escape='html'}view contact{/ts}">
                   {$contact.display_name|escape}</a>{if $contact.is_deceased} <span class="crm-contact-deceased">(deceased)</span>{/if}{if not $smarty.foreach.rel.last and $i neq 6},
                 {elseif $i eq 6}</span><span class="relblock-show-more">... <a href="#">{ts}(more){/ts}</a></span><span style="display:none">{/if}
-                  {foreach from=$settingContactFields item=field}
-                      <span>{$contact[$field]}, </span>
+                  {foreach from=$settingFields item=field name=settingFields}
+                    {if !empty($contact[$field])}
+                      <span>{$contact[$field]}{if $smarty.foreach.settingFields.last}.{else}, {/if}</span>
+                    {/if}
                   {/foreach}
                 {assign var='i' value=$i+1}
               {/foreach}

--- a/xml/Menu/relationshipblock.xml
+++ b/xml/Menu/relationshipblock.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/admin/setting/relationshipblock</path>
+    <page_callback>CRM_Admin_Form_Generic</page_callback>
+    <title>Relationship Block settings</title>
+    <desc>Settings for extension org.wikimedia.relationshipblock</desc>
+    <access_arguments>administer CiviCRM</access_arguments>
+    <adminGroup>System Settings</adminGroup>
+  </item>
+</menu>


### PR DESCRIPTION
Hi,

here is my modification for improving displaying information about contact and/or relationship.

At new setting page `civicrm/admin/setting/relationshipblock?reset=1` accessed from Admin Console you can add additional fields, like phone, email or custom fields from relationship.

* *Contact fields* - Additional contact fields displayed on block
* *Relationship fields* - Additional relationship fields displayed on block
* *Display labels* - Decide whether before value will be displayed a label of field, with options:
  * No, only value of fields
  * Yes, each field has own label

Configuration example

![relationship-block-settings](https://user-images.githubusercontent.com/8309610/158829188-bb996ccd-34aa-4111-809b-e3699ed5e889.png)

What do you think about such feature?