### PR TITLE
Fix fatal 'Invalid escape mode: html'

### DIFF
--- a/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
+++ b/templates/CRM/Relationshipblock/Page/Inline/RelationshipBlock.tpl
@@ -1,5 +1,5 @@
 <div id="crm-relblock-content" {if $permission EQ 'edit'}class="crm-inline-edit crm-clear" {literal}data-edit-params='{"cid": {/literal}{$contactId}{literal}, "class_name": "CRM_Relationshipblock_Form_Inline_RelationshipBlock"}'{/literal}{/if}>
-  <div class="crm-clear crm-inline-block-content" title="{ts escape='htmlattribute'}Edit relationships{/ts}">
+  <div class="crm-clear crm-inline-block-content" title="{ts}Edit relationships{/ts}">
     {if $permission EQ 'edit'}
       <div class="crm-edit-help"><span class="crm-i fa-pencil"></span>{ts}Edit{/ts}</div>
     {/if}
@@ -11,7 +11,7 @@
             {assign var='i' value=1}
             <span>
               {foreach from=$existingRelationship.contacts item=contact name=rel}
-                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$contact.contact_id`"}" title="{ts escape='htmlattribute'}view contact{/ts}">
+                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$contact.contact_id`"}" title="{ts}view contact{/ts}">
                   {$contact.display_name|escape}</a>{if $contact.is_deceased} <span class="crm-contact-deceased">(deceased)</span>{/if}{if not $smarty.foreach.rel.last and $i neq 6},
                 {elseif $i eq 6}</span><span class="relblock-show-more">... <a href="#">{ts}(more){/ts}</a></span><span style="display:none">{/if}
                 {assign var='i' value=$i+1}


### PR DESCRIPTION
Since we upgraded to CiviCRM 6.4, we get a fatal error when consulting a contact with relationship block.

Removing `escape='htmlattribute'` seems to solve this. I don't see any reason why it was there in the first place.